### PR TITLE
Second _SP_TEST is empty can causes a non-response

### DIFF
--- a/User_Mods/MMU/Stinger Pico MMU - @LH/Klipper/sp_mmu_code.cfg
+++ b/User_Mods/MMU/Stinger Pico MMU - @LH/Klipper/sp_mmu_code.cfg
@@ -2234,6 +2234,6 @@ gcode:
 
 #### ------ PLAYGROUND ----------
 
-[gcode_macro _SP_TEST]
-gcode:
+# [gcode_macro _SP_TEST]
+# gcode:
 


### PR DESCRIPTION
A buddy of mine mentioned the SP_TEST_MMU stopped working. I found this odd so I started poking around. Turns out that _SP_TEST is defined twice and the second is an empty macro. 

It was probably an oversight, just wanted to present this simple fix. With it commented out SP_TEST_MMU works on my machine now.