### PR TITLE
Create cutter.cfg example macros

### DIFF
--- a/User_Mods/Toolhead/Filament Cutter - Orbiter - Sherpa -  @RPi/Klipper/cutter.cfg
+++ b/User_Mods/Toolhead/Filament Cutter - Orbiter - Sherpa -  @RPi/Klipper/cutter.cfg
@@ -1,5 +1,7 @@
 # This is a working example of how to operate the cutter with an external arm/flipper driven by a servo
 #   These values should be adjusted to work with your setup
+#
+#   Use the SP_TEST_MANUAL_CUTTING macro to tune your cutting workflow values
 
 
 [servo sp_arm_servo]

--- a/User_Mods/Toolhead/Filament Cutter - Orbiter - Sherpa -  @RPi/Klipper/cutter.cfg
+++ b/User_Mods/Toolhead/Filament Cutter - Orbiter - Sherpa -  @RPi/Klipper/cutter.cfg
@@ -1,0 +1,174 @@
+# This is a working example of how to operate the cutter with an external arm/flipper driven by a servo
+#   These values should be adjusted to work with your setup
+
+
+[servo sp_arm_servo]
+pin: PICO_MMU: PB3                   # Servo pin - update to the pin you are using
+initial_angle: 100                   # the angle the servor should start at when it powers on an binds to controler
+maximum_servo_angle: 180             # maxium angle your servo can achieve - please look up your servo's specification - they can differ
+minimum_pulse_width: 0.0005          # max and min pulse widths are how the controler "instructs" the servo - please look up your servo's specification
+maximum_pulse_width: 0.0023
+
+[gcode_macro _SP_CUT_VARS]
+variable_arm_up: 100                 # angle of the arm when disengauged - the flipper is not in the path of cutting arm 
+variable_arm_down: 10                # angle of the arm when engauged - the flipper is in the path of the cutting arm
+variable_safe_max_x: 149             # the place a just before the flipper when engauged - the flipper is free to move
+variable_cut_max_x: 180              # the place where the cutting arm is at its full distance - the cut should be done - warning: watch for buckling of the cutting arm and or the flipper
+variable_cut_reps: 1                 # number of times to attempt a cut - think of chopping a tree - this could be an indicator of buckling, or dull blade
+variable_tip_length_below_cut: 15    # mm above the tip to make the cut - use this adjustment to retain a little more filament 
+variable_approach_speed: 300         # how fast the toolhead will move to the safe_max and after the cut to your purge/park spot
+variable_cut_speed: 20               # the speed the toolhead will move against the flipper. Slower is better as it adds more torque 
+variable_filament_retract_speed: 130 # how fast to retract
+variable_z_hop: 0.4                  # how hight to hop the toolhead to clear the work before cutting
+variable_angle_offset: 0             # used by the servo   
+variable_commanded_angle: -1         # keeping track of the commanded servo angle
+variable_switch_time: 1.2            # modifier to wait for the servo to complete its movement
+#debug: 1                            # flag to turn on your own debugging messages
+gcode:
+
+[gcode_macro _CHECK_HOME_X]
+gcode:
+  {% if not "x" in printer.toolhead.homed_axes and (printer.toolhead.position.x|float == 110.0) %}
+    RESPOND MSG="SP: (cutter) Homing the X axis"
+    G28 X
+  {% endif %}  
+
+[gcode_macro SP_TEST_ARM] # Handy utilit macro to test the servo (arm) and ensure its behaving correctly - no buzzing - corerct angle - speed
+gcode:
+  _SP_ARM ANGLE={params.ANGLE|float}
+  RESPOND MSG="SP: Arm angle set to: {params.ANGLE|float}"
+
+[gcode_macro _SP_ARM] # does the work of positioning the arm
+gcode:
+  {% set sc = printer['gcode_macro _SP_CUT_VARS'] %}
+  SET_GCODE_VARIABLE MACRO=_SP_CUT_VARS VARIABLE=commanded_angle VALUE={params.ANGLE|float}
+  {% set angle = params.ANGLE|float + sc.angle_offset|float %} 
+  {% set angle = [angle, printer.configfile.settings['servo sp_arm_servo'].maximum_servo_angle] | min %}   # clamping servo angle post offset
+  
+  SET_SERVO SERVO=sp_arm_servo ANGLE={angle}
+  {% if params.ANGLE|float != sc.commanded_angle %}
+    G4 P{1000*sc.switch_time}  ## waiting for servo movement to end
+  {% endif %}
+  M400
+
+  {% if debug == 1 %}
+    RESPOND MSG="DEBUG: SERVO angle: {params.ANGLE | float} deg ({angle})"
+  {% endif %}
+
+[gcode_macro SP_CUT] # call this to work though the entire cutting sequence
+gcode:
+  {% set sp = printer['gcode_macro _SP_VARS'] %}
+  {% set sc = printer['gcode_macro _SP_CUT_VARS'] %}
+  _SP_ARM_DOWN
+  _SP_CUT_AND_CLEAR
+  _SP_ARM_UP
+  G0 X{sp.park_x} F{60*sc.approach_speed} # park before handing off
+  #BRUSH
+
+[gcode_macro _SP_ARM_UP]
+gcode:
+  {% set sc = printer['gcode_macro _SP_CUT_VARS'] %}
+  _CHECK_HOME_X 
+  {% if printer.toolhead.position.x > sc.safe_max_x %}
+    G0 X{sc.safe_max_x} F{60*sc.approach_speed}
+  {% endif %}  
+  _SP_ARM ANGLE={sc.arm_up}
+
+[gcode_macro _SP_ARM_DOWN]
+gcode:
+  {% set sc = printer['gcode_macro _SP_CUT_VARS'] %}
+  _CHECK_HOME_X
+  {% if printer.toolhead.position.x > sc.safe_max_x %}
+    G0 X{sc.safe_max_x} F{60*sc.approach_speed}
+  {% endif %}  
+
+  _SP_ARM ANGLE={sc.arm_down}
+
+[gcode_macro _SP_CUT_AND_CLEAR]
+gcode:
+  {% set sc = printer['gcode_macro _SP_CUT_VARS'] %}
+  {% set sp = printer['gcode_macro _SP_VARS'] %}
+  {% set hop = [printer.toolhead.axis_maximum.z, printer.gcode_move.gcode_position.z+sc.z_hop] | min  %} 
+  {% set fil_cut_position = sp.dist_extruder_to_meltzone - sp.dist_filament_park - sc.tip_length_below_cut %}
+  {% if "z" in printer.toolhead.homed_axes and sc.z_hop > 0 %}
+    G0 Z{hop}    ## Z Hop
+  {% endif %}
+  G0 E-{fil_cut_position} F{60*sc.filament_retract_speed}      ## Retract filament close to the cutter blade 
+  {% for i in range(sc.cut_reps) %}  
+    G0 X{sc.cut_max_x} F{60*sc.approach_speed} # move to cut 
+    G0 X{sc.safe_max_x} F{60*sc.cut_speed} # back off
+  {% endfor %}
+  
+  # G0 X{sc.cut_max_x} F{60*sc.approach_speed} # move to cut 
+  # G0 X{sc.safe_max_x} F{60*sc.cut_speed} # back off
+ 
+[gcode_macro SP_TEST_MANUAL_CUTTING] # handy utility macro where you can tune your cutting workflow - this is based on the tip forming utility - use mainsail or fluidd
+gcode:
+    ## Configuration derived variables
+    {% set sc = printer['gcode_macro _SP_CUT_VARS'] %}
+    {% set sp = printer['gcode_macro _SP_VARS'] %}
+    {% set pause_retract_dist = sp.pause_retract | float %}
+    
+    ## Helper variables for extruder unload
+    {% set load_dist = sp.dist_extruder_to_meltzone*1.2 | float %} 
+    {% set load_speed = sp.speed_meltzone_loading | float %} 
+    {% set sync_dist =  sp.dist_filament_park + sp.dist_sensor_to_extruder - sp.dist_sensor_to_synced_move | float %} 
+    {% set sync_speed = sp.speed_sync_moves | float %}
+    {% set sync_accel = sp.motor_accel | float %}
+    {% set final_unload_distance = 60 | float %} 
+    {% set final_unload_speed = sp.speed_hub_to_extruder | float %}
+
+    ## Cut Test Variables
+    {% set safe_max_x = params.SAFE_MAX_X|default(149) | float %}
+    {% set cut_max_x = params.CUT_MAX_X|default(181) | float %}
+    {% set cut_reps = params.CUT_REPS|default(2) | int %}
+    {% set approach_speed = params.APPROACH_SPEED|default(300) | int %}
+    {% set cut_speed = params.CUT_SPEED|default(100) | int %}
+    {% set tip_length_below_cut = params.CUT_ABOVE_TIP|default(15) | int %}
+
+    ## Updating Cut Defaults
+    SET_GCODE_VARIABLE MACRO=_SP_CUT_VARS VARIABLE=safe_max_x VALUE={safe_max_x}
+    SET_GCODE_VARIABLE MACRO=_SP_CUT_VARS VARIABLE=cut_max_x VALUE={cut_max_x}
+    SET_GCODE_VARIABLE MACRO=_SP_CUT_VARS VARIABLE=cut_reps VALUE={cut_reps}
+    SET_GCODE_VARIABLE MACRO=_SP_CUT_VARS VARIABLE=cut_speed VALUE={cut_speed}
+    SET_GCODE_VARIABLE MACRO=_SP_CUT_VARS VARIABLE=approach_speed VALUE={approach_speed}
+    SET_GCODE_VARIABLE MACRO=_SP_CUT_VARS VARIABLE=tip_length_below_cut VALUE={tip_length_below_cut}
+
+    ## Start
+    RESPOND MSG="SP: Note: A filament strand should be pushed against the extruder gears"
+    RESPOND MSG="SP: Starting Filament Cutting Test"
+
+    {% if printer[printer.toolhead.extruder].can_extrude == True %}
+      _SP_DISABLE_PA
+      _SP_DISABLE_MPC
+      M83         
+     
+      ### Loading filament
+      RESPOND MSG="SP: Loading Hotend"
+      G0 E{load_dist/2} F{final_unload_speed*60}    ## Loading hotend
+      G0 E{load_dist/2} F{load_speed*60}      ## Loading meltzone
+      G4 P500 
+
+      #### Simulating print, pause and initial retract to get more accurate tip forming samples ####
+      RESPOND MSG="SP: Simulating print"
+      G0 E7 F{4*30}                        ## Printing - 7mm of prime
+      G4 P2000                             ## Filament change pause 
+      G0 E-{pause_retract_dist} F{35*60}   ## Pause retract
+
+      #### Tip Forming ####
+      SP_CUT
+
+      #### Done - Unloading extruder ####
+      M400
+      RESPOND MSG="SP: Unloading extruder"
+      G4 P1000 ## Simulating servo movement pause
+      FORCE_MOVE STEPPER=extruder VELOCITY={sync_speed} ACCEL={sync_accel} DISTANCE=-{sync_dist}   ## Simulating sync extruder unloading move
+      G0 E-{final_unload_distance} F{final_unload_speed*60}  ## Unloading the filament out of the extruder gears to be picked by hand and inspected
+
+      M400
+      RESPOND MSG="SP: DONE! Pleast remove the filament gently and inspect the tip"
+      RESPOND MSG=""
+    
+    {% else %}
+      RESPOND MSG="SP: Please heat up the hotend"
+    {% endif %}


### PR DESCRIPTION
A slightly more robust set of macros to be used as an example for your cutting workflow process.

This is what I am currently using on my printer.