### PR TITLE
Proposal to keep warmer temperature while purging during load

### DIFF
--- a/User_Mods/MMU/Stinger Pico MMU - @LH/Klipper/sp_mmu_code.cfg
+++ b/User_Mods/MMU/Stinger Pico MMU - @LH/Klipper/sp_mmu_code.cfg
@@ -912,6 +912,7 @@ gcode:
   {% set force = params.FORCE | default(0) | int %}
   {% set hotend_loaded = printer.save_variables.variables.hotend_loaded | default(-1) | int %}
   {% set purge = params.PURGE|default(0) | int %}
+  {% set request_temp = params.TEMP | default(0) | int %}
   
   {% if rt.exit_code == 0 %} 
     RESPOND MSG="SP: Loading Hotend ..."
@@ -928,10 +929,15 @@ gcode:
 
         _SP_NOTIFY ACTION="hotend_loading" LANE={rt.loading_lane} COMPLETE=0
       
-        {% set extruder_temp = params.TEMP | default(0) | int %}
+        {% if rt.curr_lane_temp > request_temp %} 
+          {% set extruder_temp = rt.curr_lane_temp | int %} 
+          RESPOND MSG="SP: The previous lane used a higer temp ({rt.curr_lane_temp}C)"
+        {% else %}
+          {% set extruder_temp = request_temp | int %} 
+        {% endif %}
     
         SP_HOME
-        _SP_HEAT_HOTEND TEMP={params.TEMP}
+        _SP_HEAT_HOTEND TEMP={extruder_temp}
         
         {% set dist = sp.dist_extruder_to_meltzone - sp.dist_filament_park - sp.tip_length_below_cut %}
         {% if sp.end_of_load_filament_move < 0 %}  ## if a negative end of load move is set, we subtract the distance
@@ -951,6 +957,9 @@ gcode:
           G1 E{purge} F{60*(sp.purge_speed/2.4)}  ## conversion from mm3/s to mm/s 
           RESPOND MSG="SP: Purging {purge}mm of filament"
         {% endif %}
+
+        rt.curr_lane_temp = request_temp
+        RESPOND MSG="SP: Saving the current lane temp ({request_temp}C)"
         
         M400
         SAVE_VARIABLE VARIABLE=hotend_loaded VALUE=1
@@ -2318,6 +2327,7 @@ variable_motor_last_direction: -1   # tracks last move direction for backlash co
 variable_motor_last_loaded_lane: -1 # tracks last selected lane for backlash compensation
 variable_min_home_move: 30          # setting a minimum home move length to try and avoid timer too close errors
 variable_next_purge: 60             # mm of filament purged at the next lane change - set by the slicer
+variable_curr_lane_temp: 0
 variable_print_start_change: 0      # tracks if a filament change was required during _SP_PRINT_START
 variable_user_macros_executed: 0    # tracks user macros execution
 variable_sp_pause: 0                # tracks if sp pause was executed


### PR DESCRIPTION
When switching between PTEG and PLA filaments, we do not want the PETG that is still in the nozzle getting purged with the PLA temps as the hotend is getting loaded.

Use the warmer temperature between the two for the purge, then save the temperature of the currently loaded lane for the following filament change comparison